### PR TITLE
fix(frontend): UI Copilot click block and accessibility warnings

### DIFF
--- a/Frontend/client/src/features/copilot/PageCopilot.tsx
+++ b/Frontend/client/src/features/copilot/PageCopilot.tsx
@@ -168,10 +168,10 @@ export function PageCopilot({
 
       {/* ── Floating Chat Panel ── */}
       <div
-        className={`pointer-events-auto origin-bottom-right transition-all duration-300 ease-out flex flex-col w-[360px] h-[520px] rounded-xl glass shadow-2xl overflow-hidden ${
-          open ? "scale-100 opacity-100 translate-y-0" : "scale-95 opacity-0 translate-y-8 pointer-events-none"
+        className={`origin-bottom-right transition-all duration-300 ease-out flex flex-col w-[360px] h-[520px] rounded-xl glass shadow-2xl overflow-hidden ${
+          open ? "scale-100 opacity-100 translate-y-0 pointer-events-auto" : "scale-95 opacity-0 translate-y-8 pointer-events-none"
         }`}
-        aria-hidden={!open}
+        inert={!open ? true : undefined}
       >
         {/* Header */}
         <div className="shrink-0 px-4 py-3 bg-muted/80 backdrop-blur-md border-b border-border flex items-center gap-3">


### PR DESCRIPTION
Uses inert instead of aria-hidden and fixes click blocking in PageCopilot